### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
 
       it "checks for conflicting root URL" do
         old_spec = BottleSpecification.new
-        old_spec.root_url("https://failbrew.bintray.com/bottles")
+        old_spec.root_url("https://failbrew\.bintray\.com/bottles")
         new_hash = { "root_url" => "https://testbrew.bintray.com/bottles" }
         expect(homebrew.merge_bottle_spec([:root_url], old_spec, new_hash)).to eq [
           ['root_url: old: "https://failbrew.bintray.com/bottles", new: "https://testbrew.bintray.com/bottles"'],


### PR DESCRIPTION
Potential fix for [https://github.com/Kaustavpal007/brew/security/code-scanning/1](https://github.com/Kaustavpal007/brew/security/code-scanning/1)

To fix the problem, we need to escape the `.` characters in the URL string `https://failbrew.bintray.com/bottles` to ensure that it is treated as a literal dot rather than a meta-character in a regular expression. This can be done by replacing each `.` with `\.`. This change will ensure that the URL string matches exactly as intended and does not allow for any unintended matches.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
